### PR TITLE
Move fullscreen exit formatting to an eventListener

### DIFF
--- a/src/widget.ts
+++ b/src/widget.ts
@@ -1350,17 +1350,11 @@ export class SigmaView extends DOMWidgetView {
   }
 
   bindFullscreenHandlers() {
+    document.addEventListener('fullscreenchange', () => { this.fullscreenExitHandler() }, false);
+
     this.fullscreenButton.onclick = () => {
       if (screenfull.isFullscreen) {
-        screenfull.exit().then(() => {
-          const targetHeight = this.model.get('height') + 'px';
-
-          this.el.style.height = targetHeight;
-          this.container.style.height = targetHeight;
-          this.fullscreenButton.innerHTML = fullscreenEnterIcon;
-          this.fullscreenButton.setAttribute('title', 'enter fullscreen');
-          this.renderer.scheduleRefresh();
-        });
+        screenfull.exit()
       } else {
         screenfull.request(this.el).then(() => {
           this.el.style.height = '100%';
@@ -1372,6 +1366,17 @@ export class SigmaView extends DOMWidgetView {
       }
     };
   }
+
+  fullscreenExitHandler() {
+    if (!screenfull.isFullscreen) {
+      const targetHeight = this.model.get('height') + 'px';
+      this.el.style.height = targetHeight;
+      this.container.style.height = targetHeight;
+      this.fullscreenButton.innerHTML = fullscreenEnterIcon;
+      this.fullscreenButton.setAttribute('title', 'enter fullscreen');
+      this.renderer.scheduleRefresh();
+    }
+  };
 
   bindLayoutHandlers() {
     const graph = this.graph;


### PR DESCRIPTION
#130 

Changing the re-sizing of the divs from the fullscreenButton.onclick to a seperate function. This allows the formatting to apply even when the fullscreen is exitied with the escape key instead of the fullscreenButton.

This is my first time writing anything in TypeScript, but I tried following what was in the surrounding methods.